### PR TITLE
Improve solar system visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,9 @@ const planets = [
     w: 29.1241, wd: 1.01444e-5,
     a: 0.387098,
     e: 0.205635, ed: 5.59e-10,
-    M: 168.6562, Md: 4.0923344368
+    M: 168.6562, Md: 4.0923344368,
+    color: '#b1b1b1',
+    size: 2.5
   },
   {
     name: 'Venus',
@@ -36,7 +38,9 @@ const planets = [
     w: 54.8910, wd: 1.38374e-5,
     a: 0.723330,
     e: 0.006773, ed: -1.302e-9,
-    M: 48.0052, Md: 1.6021302244
+    M: 48.0052, Md: 1.6021302244,
+    color: '#e5c97d',
+    size: 3.9
   },
   {
     name: 'Earth',
@@ -45,7 +49,9 @@ const planets = [
     w: 282.9404, wd: 4.70935e-5,
     a: 1.0,
     e: 0.016709, ed: -1.151e-9,
-    M: 356.0470, Md: 0.9856002585
+    M: 356.0470, Md: 0.9856002585,
+    color: '#5f9df7',
+    size: 4
   },
   {
     name: 'Mars',
@@ -54,7 +60,9 @@ const planets = [
     w: 286.5016, wd: 2.92961e-5,
     a: 1.523688,
     e: 0.093405, ed: 2.516e-9,
-    M: 18.6021, Md: 0.5240207766
+    M: 18.6021, Md: 0.5240207766,
+    color: '#cf5a3e',
+    size: 2.9
   },
   {
     name: 'Jupiter',
@@ -63,7 +71,9 @@ const planets = [
     w: 273.8777, wd: 1.64505e-5,
     a: 5.20256,
     e: 0.048498, ed: 4.469e-9,
-    M: 19.8950, Md: 0.0830853001
+    M: 19.8950, Md: 0.0830853001,
+    color: '#d6b082',
+    size: 13.4
   },
   {
     name: 'Saturn',
@@ -72,7 +82,9 @@ const planets = [
     w: 339.3939, wd: 2.97661e-5,
     a: 9.55475,
     e: 0.055546, ed: -9.499e-9,
-    M: 316.9670, Md: 0.0334442282
+    M: 316.9670, Md: 0.0334442282,
+    color: '#d8c48c',
+    size: 12.3
   },
   {
     name: 'Uranus',
@@ -81,7 +93,9 @@ const planets = [
     w: 96.6612, wd: 3.0565e-5,
     a: 19.18171, ad: -1.55e-8,
     e: 0.047318, ed: 7.45e-9,
-    M: 142.5905, Md: 0.011725806
+    M: 142.5905, Md: 0.011725806,
+    color: '#7ad7f0',
+    size: 8
   },
   {
     name: 'Neptune',
@@ -90,7 +104,9 @@ const planets = [
     w: 272.8461, wd: -6.027e-6,
     a: 30.05826, ad: 3.313e-8,
     e: 0.008606, ed: 2.15e-9,
-    M: 260.2471, Md: 0.005995147
+    M: 260.2471, Md: 0.005995147,
+    color: '#4976f3',
+    size: 7.9
   }
 ];
 
@@ -127,21 +143,31 @@ function position(p, d){
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
 
+  const sunRadius = 40;
+  const scale = 10;
+  const offset = sunRadius + 20;
+
   ctx.fillStyle='yellow';
   ctx.beginPath();
-  ctx.arc(centerX, centerY, 12, 0, Math.PI*2); ctx.fill();
+  ctx.arc(centerX, centerY, sunRadius, 0, Math.PI*2); ctx.fill();
+
+  ctx.font = '12px sans-serif';
+  ctx.textBaseline = 'middle';
 
   const now = Date.now();
-  const d = (now - J2000)/86400000;
+  const d = (now - J2000)/86400000 * 1000; // speed x1000
   planets.forEach(p=>{
     const pos = position(p,d);
-    const scale = 15; // scale for display
-    const x = centerX + pos.x*scale;
-    const y = centerY + pos.y*scale;
+    const r = Math.sqrt(pos.x*pos.x + pos.y*pos.y);
+    const factor = (r*scale + offset)/r;
+    const x = centerX + pos.x*factor;
+    const y = centerY + pos.y*factor;
     ctx.fillStyle = p.color || 'white';
     ctx.beginPath();
-    ctx.arc(x, y, Math.max(2, Math.log10(p.a)*3), 0, Math.PI*2);
+    ctx.arc(x, y, p.size, 0, Math.PI*2);
     ctx.fill();
+    ctx.fillStyle = '#fff';
+    ctx.fillText(p.name, x + p.size + 4, y);
   });
 
   requestAnimationFrame(draw);


### PR DESCRIPTION
## Summary
- add colour and size metadata for each planet
- offset orbits so planets avoid the sun
- draw labels and scale planet sizes more realistically
- speed up orbital motion by 1000x

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd285d68c83339ce24e1775e20fed